### PR TITLE
fix(focusableTappable): no event case

### DIFF
--- a/clear-ui-base/src/tappable/focusableTappable.js
+++ b/clear-ui-base/src/tappable/focusableTappable.js
@@ -139,7 +139,7 @@ export default class FocusableTappable extends React.Component {
 			setTimeout(() => {
 				this.pressed = false
 				this.onChangeTapState()
-				if (this.props.onTapEnd) this.props.onTapEnd()
+				if (this.props.onTapEnd) this.props.onTapEnd(event)
 			}, 150)
 		}
 	}


### PR DESCRIPTION
Cannot read property 'type' of undefined

```js
FocusableTappable.prototype.onTapEnd = function onTapEnd(event) {
if (event.type === 'touchend') event.preventDefault(); // always prevent on touch
if (this.props.onTapEnd) this.props.onTapEnd(event);
};
```